### PR TITLE
Fix logging initialization

### DIFF
--- a/backend/logging_config.py
+++ b/backend/logging_config.py
@@ -412,11 +412,8 @@ def get_log_stats() -> Dict[str, Any]:
     return stats
 
 
-# Initialize logging when module is imported
-setup_logging()
-
 # Create logger instances for different components
 api_logger = get_logger("api")
 agent_logger = get_logger("agents")
 scheduler_logger = get_logger("scheduler")
-database_logger = get_logger("database") 
+database_logger = get_logger("database")

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -2,8 +2,16 @@ import pytest
 from unittest.mock import patch, Mock
 from agents.aviation_pages_reader import fetch_skywest_news
 from agents.newsdata_agent import fetch_newsdata_news
-from agents.institutional_reader import fetch_institutional_news, fetch_reuters_aviation
+from agents.institutional_reader import (
+    fetch_institutional_news,
+    fetch_reuters_aviation,
+)
 from agents.groundnews_agent import fetch_groundnews_articles
+
+# Explicitly configure logging for the tests
+from logging_config import setup_logging
+
+setup_logging(enable_file=False)
 
 
 class TestAviationPagesReader:


### PR DESCRIPTION
## Summary
- remove automatic `setup_logging()` call from `logging_config`
- configure logging explicitly in `test_agents`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6857258d0f9c832ea2ee9ec48bbe4097